### PR TITLE
Add x-checker-data

### DIFF
--- a/org.freedesktop.LinuxAudio.Plugins.ZamPlugins.json
+++ b/org.freedesktop.LinuxAudio.Plugins.ZamPlugins.json
@@ -42,7 +42,12 @@
                 {
                     "type": "git",
                     "url": "https://github.com/zamaudio/zam-plugins.git",
-                    "tag": "3.14"
+                    "tag": "3.14",
+                    "commit": "e7077fcc0b7f60daa7471eae42015ffc9cba73d9",
+                    "x-checker-data": {
+                        "type": "git",
+                        "tag-pattern": "^([\\d.]+)$"
+                    }
                 },
                 {
                     "type": "file",


### PR DESCRIPTION
I think this also works for plugins? f-e-d-c seemed to think it was fine when running locally.

Also you might want to set 20.08 as the default branch.